### PR TITLE
Fix assume preauthentication

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/jcmturner/gokrb5.v7/config"
+	"github.com/jcmturner/gokrb5.v7/keytab"
+
+)
+
+func TestAssumePreauthentication(t *testing.T) {
+	t.Parallel()
+
+	cl := NewClientWithKeytab("username", "REALM", &keytab.Keytab{}, &config.Config{}, AssumePreAuthentication(true))
+	if !cl.settings.assumePreAuthentication {
+		t.Fatal("assumePreAuthentication should be true")
+	}
+	if !cl.settings.AssumePreAuthentication() {
+		t.Fatal("AssumePreAuthentication() should be true")
+	}
+}

--- a/client/settings.go
+++ b/client/settings.go
@@ -38,7 +38,7 @@ func (s *Settings) DisablePAFXFAST() bool {
 // s := NewSettings(AssumePreAuthentication(true))
 func AssumePreAuthentication(b bool) func(*Settings) {
 	return func(s *Settings) {
-		s.disablePAFXFast = b
+		s.assumePreAuthentication = b
 	}
 }
 


### PR DESCRIPTION
This PR merges this change into master so it can be used immediately: https://github.com/jcmturner/gokrb5/pull/336. Later if/when it's added in the upstream library, upstream changes will be pulled into master and reconciled.