### PR TITLE
Fix readBytes panic in keytab package

### DIFF
--- a/keytab/keytab.go
+++ b/keytab/keytab.go
@@ -361,7 +361,7 @@ func readBytes(b []byte, p *int, s int, e *binary.ByteOrder) ([]byte, error) {
 	}
 	i := *p+s
 	if i > len(b) {
-		return nil, fmt.Errorf("%s's length is less than %d", b, i)
+		return nil, fmt.Errorf("%s's length is greater than %d", b, i)
 	}
 	buf := bytes.NewBuffer(b[*p : i])
 	r := make([]byte, s)

--- a/keytab/keytab_test.go
+++ b/keytab/keytab_test.go
@@ -1,6 +1,7 @@
 package keytab
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"os"
 	"path/filepath"
@@ -91,5 +92,20 @@ func TestLoad(t *testing.T) {
 		if e.KVNO8 == uint8(0) {
 			t.Error("entry kvno8 not as expected")
 		}
+	}
+}
+
+// This test provides inputs to readBytes that previously
+// caused a panic.
+func TestReadBytes(t *testing.T) {
+	var endian binary.ByteOrder
+	endian = binary.BigEndian
+	p := 0
+
+	if _, err := readBytes(nil, &p, 1, &endian); err == nil {
+		t.Fatal("err should be populated because s was given that exceeds array length")
+	}
+	if _, err := readBytes(nil, &p, -1, &endian); err == nil {
+		t.Fatal("err should be given because negative s was given")
 	}
 }


### PR DESCRIPTION
This PR moves https://github.com/jcmturner/gokrb5/pull/340 to master immediately so we can use it. If/when it's merged upstream later, we can pull it in and reconcile any differences.