### PR TITLE
length check when parsing krb5tokens

### DIFF
--- a/spnego/krb5Token.go
+++ b/spnego/krb5Token.go
@@ -71,6 +71,9 @@ func (m *KRB5Token) Unmarshal(b []byte) error {
 		return fmt.Errorf("error unmarshalling KRB5Token OID: %v", err)
 	}
 	m.OID = oid
+	if len(r) < 2 {
+		return fmt.Errorf("krb5token too short")
+	}
 	m.tokID = r[0:2]
 	switch hex.EncodeToString(m.tokID) {
 	case TOK_ID_KRB_AP_REQ:


### PR DESCRIPTION
This PR is to move the code originally PR'd https://github.com/hashicorp/vault-plugin-auth-kerberos/pull/29 and currently also PR'd upstream https://github.com/jcmturner/gokrb5/pull/341 to master for immediate use. If/when it's merged upstream, we can pull in upstream master and reconcile any differences that arise.